### PR TITLE
Version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] / 2025-10-31
+### Features
+- Add `SetName` to set the name of a ribbon item and update the `ToolTip` title.
+### Fixes
+- Fix `Name` should be used in the `ToolTip.Title` (Fix #5)
+
 ## [0.4.0] / 2025-07-18
 ### Features
 - Support `AddSlideOut` extension.
@@ -62,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `Busy`, `Runtime`, `Tasks`, and `Windows` utilities.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[0.4.1]: ../../compare/0.4.0...0.4.1
 [0.4.0]: ../../compare/0.3.0...0.4.0
 [0.3.0]: ../../compare/0.2.0...0.3.0
 [0.2.0]: ../../compare/0.1.0...0.2.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-	<PropertyGroup>
-		<Version>0.4.1-rc</Version>
-	</PropertyGroup>
+  <PropertyGroup>
+    <Version>0.4.1</Version>
+  </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.4.1-beta</Version>
+		<Version>0.4.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.4.1-alpha</Version>
+		<Version>0.4.1-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>0.4.0</Version>
+		<Version>0.4.1-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,52 @@ public class MyExtensionApp : ExtensionApplication
 }
 ```
 
+### RibbonExtension
+
+The `RibbonExtension` class offers extension methods to create and manage ribbon panels, buttons, and other UI elements in AutoCAD.
+```C#
+using ricaun.AutoCAD.UI;
+using Autodesk.AutoCAD.Runtime;
+
+[assembly: ExtensionApplication(MyExtensionApp)]
+
+public class MyExtensionApp : ExtensionApplication
+{
+    public override void OnStartup(RibbonControl ribbonControl)
+    {
+        var ribbonPanel = ribbonControl.CreatePanel("MyPanel");
+
+        ribbonPanel.CreateButton("MyButton")
+            .SetText("Click Me")
+            .SetDescription("This is a button description")
+            .SetToolTip("This is a button tooltip")
+            .SetImage("Resources/image16-light.png")
+            .SetLargeImage("Resources/image32-light.png")
+            .SetCommand(() => 
+            {
+                // Button click logic here
+            });
+    }
+
+    public override void OnShutdown(RibbonControl ribbonControl)
+    {
+        ribbonControl.RemovePanel("MyPanel");
+    }
+}
+```
+
+### Ribbon Image - Theme Change Support
+
+The `SetImage` and `SetLargeImage` methods automatically handle theme changes based in the key name `light` and `dark` in the image file names.
+
+```C#
+ribbonPanel.CreateButton("MyButton")
+    .SetImage("Resources/image16-light.png") // If the theme is dark, it will use "Resources/image16-dark.png" internally
+    .SetLargeImage("Resources/image32-light.png"); // If the theme is dark, it will use "Resources/image32-dark.png" internally
+```
+
+When the AutoCAD theme changes, the ribbon button images will automatically update to match the current theme.
+
 ## Release
 
 * [Latest release](https://github.com/ricaun-io/ricaun.AutoCAD.UI/releases/latest)

--- a/ricaun.AutoCAD.UI.Example/App.cs
+++ b/ricaun.AutoCAD.UI.Example/App.cs
@@ -88,33 +88,46 @@ namespace ricaun.AutoCAD.UI.Example
                 .SetCommand(() => { paletteSet?.ToggleVisible(); })
                 .SetLargeImage("Resources/Cube-Grey-Light.tiff");
 
+            ribbonPanel.CreateButton("Button Name")
+                .SetLargeImage("Resources/Cube-Grey-Light.tiff")
+                .SetText("Button Text")
+                .SetDescription("This is a Description")
+                .SetToolTip("This is a ToolTip");
+
             ribbonPanel.AddSeparator();
 
             ribbonPanel.CreateSplitButton("Split", 
-                ribbonPanel.CreateButton("Grey")
+                ribbonPanel.CreateButton("Grey\rName")
+                    .SetText("Grey\rText")
                     .SetCommand(e=>Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Grey-Light.tiff"),
-                ribbonPanel.CreateButton("Red")
+                ribbonPanel.CreateButton("Red\rName")
+                    .SetText("Red\rText")
                     .SetCommand(e => Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Red-Light.tiff"),
-                ribbonPanel.CreateButton("Green")
+                ribbonPanel.CreateButton("Green\rName")
+                    .SetText("Green\rText")
                     .SetCommand(e => Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Green-Light.tiff")
             );
 
             ribbonPanel.CreatePulldownButton("Pulldown",
                 ribbonPanel.CreateButton("Grey")
+                    .SetText("Grey Text")
                     .SetCommand(e => Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Grey-Light.tiff"),
                 ribbonPanel.CreateButton("Red")
+                    .SetText("Red Text")
                     .SetCommand(e => Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Red-Light.tiff"),
                 ribbonPanel.CreateButton("Green")
+                    .SetText("Green Text")
                     .SetCommand(e => Windows.MessageBox.ShowMessage(e.Text))
                     .SetLargeImage("Resources/Cube-Green-Light.tiff")
             )
             .SetLargeImage("Resources/Cube-Green-Light.tiff")
-            .SetDescription("This is a PulldownButton");
+            .SetDescription("This is a PulldownButton")
+            .SetText("Pulldown Text");
 
             ribbonPanel.CreateToggleButton("Toggle")
                 .SetCommand(e => e.Text = $"{e.Name}\r{e.IsChecked}")

--- a/ricaun.AutoCAD.UI/RibbonExtension.cs
+++ b/ricaun.AutoCAD.UI/RibbonExtension.cs
@@ -162,7 +162,7 @@ namespace ricaun.AutoCAD.UI
         }
 
         /// <summary>
-        /// Sets the text of a ribbon item and updates its tooltip title.
+        /// Sets the text of a ribbon item and updates to show the text.
         /// </summary>
         /// <typeparam name="TRibbonItem">The type of ribbon item.</typeparam>
         /// <param name="ribbonItem">The ribbon item to extend.</param>
@@ -174,11 +174,27 @@ namespace ricaun.AutoCAD.UI
             {
                 ribbonItem.ShowText = true;
                 ribbonItem.Text = value;
-                if (ribbonItem.ToolTip is RibbonToolTip toolTip) toolTip.Title = value;
             }
             else
             {
                 ribbonItem.ShowText = false;
+            }
+            return ribbonItem;
+        }
+
+        /// <summary>
+        /// Sets the name of a ribbon item and updates its tooltip title.
+        /// </summary>
+        /// <typeparam name="TRibbonItem">The type of ribbon item.</typeparam>
+        /// <param name="ribbonItem">The ribbon item to extend.</param>
+        /// <param name="value">The name value to set.</param>
+        /// <returns>The ribbon item with the updated name.</returns>
+        public static TRibbonItem SetName<TRibbonItem>(this TRibbonItem ribbonItem, string value) where TRibbonItem : RibbonItem
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                ribbonItem.Name = value;
+                if (ribbonItem.ToolTip is RibbonToolTip toolTip) toolTip.Title = value; 
             }
             return ribbonItem;
         }
@@ -252,7 +268,7 @@ namespace ricaun.AutoCAD.UI
             {
                 ribbonItem.ToolTip = new RibbonToolTip()
                 {
-                    Title = ribbonItem.Text,
+                    Title = ribbonItem.Name,
                     Content = ribbonItem.Description
                 };
             }

--- a/ricaun.AutoCAD.UI/RibbonExtension.cs
+++ b/ricaun.AutoCAD.UI/RibbonExtension.cs
@@ -2,9 +2,7 @@
 using ricaun.AutoCAD.UI.Input;
 using ricaun.AutoCAD.UI.Utils;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Media;
 
@@ -168,6 +166,9 @@ namespace ricaun.AutoCAD.UI
         /// <param name="ribbonItem">The ribbon item to extend.</param>
         /// <param name="value">The text value to set.</param>
         /// <returns>The ribbon item.</returns>
+        /// <remarks>
+        /// The Name and Text properties are used to store long and short names for the item. Text is used in the item in the ribbon and Name is used in customization dialog.
+        /// </remarks>
         public static TRibbonItem SetText<TRibbonItem>(this TRibbonItem ribbonItem, string value) where TRibbonItem : RibbonItem
         {
             if (!string.IsNullOrEmpty(value))
@@ -189,6 +190,9 @@ namespace ricaun.AutoCAD.UI
         /// <param name="ribbonItem">The ribbon item to extend.</param>
         /// <param name="value">The name value to set.</param>
         /// <returns>The ribbon item with the updated name.</returns>
+        /// <remarks>
+        /// The Name and Text properties are used to store long and short names for the item. Text is used in the item in the ribbon and Name is used in customization dialog.
+        /// </remarks>
         public static TRibbonItem SetName<TRibbonItem>(this TRibbonItem ribbonItem, string value) where TRibbonItem : RibbonItem
         {
             if (!string.IsNullOrEmpty(value))


### PR DESCRIPTION
### Features
- Add `SetName` to set the name of a ribbon item and update the `ToolTip` title.
### Fixes
- Fix `Name` should be used in the `ToolTip.Title` (Fix #5)